### PR TITLE
Tweak DB connections

### DIFF
--- a/packages/app/src/lib/db.ts
+++ b/packages/app/src/lib/db.ts
@@ -2,6 +2,9 @@ import { Pool } from "pg";
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  ssl: {
+    rejectUnauthorized: false,
+  },
 });
 
 export interface Interest {

--- a/packages/indexer/src/lib/db.ts
+++ b/packages/indexer/src/lib/db.ts
@@ -8,6 +8,7 @@ const openai = new OpenAI({
 
 const client = new Client({
   connectionString: process.env.DATABASE_URL,
+  ssl: true,
 });
 
 export async function connectToDatabase() {


### PR DESCRIPTION
## About

- Enable us to pass in the DB URL without specifying `ssl=true` in the DB string
- Silence the warnings in the logs about using a self-signed cert